### PR TITLE
Teamrol openen in een nieuw tablad

### DIFF
--- a/index.html
+++ b/index.html
@@ -524,63 +524,63 @@
                 <p>Klik voor meer info</p>
 
 
-                <a href="https://belbin.nl/teamrolmodel/teamrollen/voorzitter">
+                <a href="https://belbin.nl/teamrolmodel/teamrollen/voorzitter" target="_blank">
                     <div class="solutionCard vz">
                         <h3>Voorzitter: </h3>
                         <h4 id="vz_val">0%</h4>
                     </div> 
                 </a>
 
-                <a href="https://belbin.nl/teamrolmodel/teamrollen/vormer">
+                <a href="https://belbin.nl/teamrolmodel/teamrollen/vormer" target="_blank">
                     <div class="solutionCard vm">
                         <h3>Vormer: </h3>
                         <h4 id="vm_val">0%</h4>
                     </div>
                 </a>
         
-                <a href="https://belbin.nl/teamrolmodel/teamrollen/plant">
+                <a href="https://belbin.nl/teamrolmodel/teamrollen/plant" target="_blank">
                     <div class="solutionCard pl">
                         <h3>Plant: </h3>
                         <h4 id="pl_val">0%</h4>
                     </div>
                 </a>
 
-                <a href="https://belbin.nl/teamrolmodel/teamrollen/monitor">
+                <a href="https://belbin.nl/teamrolmodel/teamrollen/monitor" target="_blank">
                     <div class="solutionCard mo">
                         <h3>Monitor: </h3>
                         <h4 id="mo_val">0%</h4>
                     </div>
                 </a>
 
-                <a href="https://belbin.nl/teamrolmodel/teamrollen/bedrijfsman">
+                <a href="https://belbin.nl/teamrolmodel/teamrollen/bedrijfsman" target="_blank">
                     <div class="solutionCard bm">
                         <h3>Bedrijfsman: </h3>
                         <h4 id="bm_val">0%</h4>
                     </div>
                 </a>
 
-                <a href="https://belbin.nl/teamrolmodel/teamrollen/brononderzoeker">
+                <a href="https://belbin.nl/teamrolmodel/teamrollen/brononderzoeker" target="_blank">
                     <div class="solutionCard bo">
                         <h3>Brononderzoek: </h3>
                         <h4 id="bo_val">0%</h4>
                     </div>
                 </a>
 
-                <a href="https://belbin.nl/teamrolmodel/teamrollen/groepswerker">
+                <a href="https://belbin.nl/teamrolmodel/teamrollen/groepswerker" target="_blank">
                     <div class="solutionCard gw">
                         <h3>Groepswerker: </h3>
                         <h4 id="gw_val">0%</h4>
                     </div>
                 </a>
 
-                <a href="https://belbin.nl/teamrolmodel/teamrollen/zorgdrager">
+                <a href="https://belbin.nl/teamrolmodel/teamrollen/zorgdrager" target="_blank">
                     <div class="solutionCard zd">
                         <h3>Zorgdrager: </h3>
                         <h4 id="zd_val">0%</h4>
                     </div>
                 </a>
 
-                <a href="https://belbin.nl/teamrolmodel/teamrollen/specialist">
+                <a href="https://belbin.nl/teamrolmodel/teamrollen/specialist" target="_blank">
                     <div class="solutionCard sp">
                         <h3>Specialist: </h3>
                         <h4 id="sp_val">0%</h4>


### PR DESCRIPTION
Wanneer je nu op een teamrol klikt op de uitslag pagina om te kijken wat hij inhoud. Gaat de pagina naar de website van belbin. 
Wanneer je terug gaat naar de test ben je de uitslag kwijt. De test start dan van het begin af aan. 

Door deze target blanks, wordt er een nieuw tabblad geopend als je op een teamrol klikt. Je test uitslag blijft dan gewoon staan.